### PR TITLE
Fixed usage of getElementsByClassName.

### DIFF
--- a/player/framelist.js
+++ b/player/framelist.js
@@ -179,7 +179,7 @@ var sozi = sozi || {};
     }
 
     function onFrameChange(index) {
-        var current = linksBox.getElementsByClassName("sozi-toc-current"),
+        var current = document.getElementsByClassName("sozi-toc-current"),
             textElements = linksBox.getElementsByTagName("text"),
             i;
         for (i = 0; i < current.length; i += 1) {


### PR DESCRIPTION
IE9 does not support getElementsByClassName on elements other than
HTMLDocument for SVG documents.
