### PR TITLE
Add package target.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,43 @@ CMAKE_MINIMUM_REQUIRED(VERSION 2.6)
 
 PROJECT(sozi)
 
+################################################################################
+### Compute the sozi version with the current date
+################################################################################
+
+IF (WIN32)
+    # FIXME
+    EXECUTE_PROCESS(COMMAND "cmd" " /C date /T" OUTPUT_VARIABLE SOZI_VERSION)
+    STRING(REGEX REPLACE "(..)/(..)/..(..).*" "\\3\\2\\1" SOZI_VERSION ${SOZI_VERSION})
+ELSEIF(UNIX)
+    EXECUTE_PROCESS(COMMAND "date" "+%y.%m-%d%H%M%S" OUTPUT_VARIABLE SOZI_VERSION)
+    STRING(REPLACE "\n" "" SOZI_VERSION ${SOZI_VERSION})
+ELSE (WIN32)
+    MESSAGE(SEND_ERROR "date not implemented")
+    SET(SOZI_VERSION 000000)
+ENDIF (WIN32)
+
+#MESSAGE(STATUS "SOZI_VERSION=${SOZI_VERSION}")
+
+################################################################################
+### Recurse to subfolders
+################################################################################
+
+ADD_SUBDIRECTORY(doc)
 ADD_SUBDIRECTORY(player)
 ADD_SUBDIRECTORY(editors)
 
+################################################################################
+### Packaging
+################################################################################
+
+SET(CPACK_PACKAGE_NAME                "sozi")
+SET(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Sozi is a zooming presentation program")
+SET(CPACK_PACKAGE_VERSION             "${SOZI_VERSION}")
+
+SET(CPACK_GENERATOR                   "TGZ")
+SET(CPACK_ARCHIVE_COMPONENT_INSTALL   "ON")
+SET(CPACK_COMPONENTS_GROUPING         "IGNORE")
+
+INCLUDE(CPack)
 

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -1,0 +1,10 @@
+SET(sozi_doc_files ${CMAKE_CURRENT_SOURCE_DIR}/GPL-license.txt  
+                   ${CMAKE_CURRENT_SOURCE_DIR}/MIT-license.txt  
+                   ${PROJECT_SOURCE_DIR}/README)
+
+### Hugly hack
+SET(sozi_doc_files ${sozi_doc_files} PARENT_SCOPE)
+
+INSTALL(FILES ${sozi_doc_files}
+        DESTINATION share/doc/sozi
+        COMPONENT doc)

--- a/editors/inkscape/CMakeLists.txt
+++ b/editors/inkscape/CMakeLists.txt
@@ -1,29 +1,15 @@
 ################################################################################
-#
-#  The inkscape home or prefix option
-#
-################################################################################
-
-SET(inkscape_path "$ENV{HOME}/.config/inkscape" CACHE PATH "Path to inkscape extensions dir (${CMAKE_INSTALL_PREFIX}/share/inkscape for global install)")
-
-################################################################################
 ### The sozi.py output file contains the sozi inkscape integration
 ################################################################################
 
-EXECUTE_PROCESS(
-	COMMAND date +%y.%m-%d%H%M%S
-	OUTPUT_VARIABLE sozi_version
-	OUTPUT_STRIP_TRAILING_WHITESPACE
-)
-
 ADD_CUSTOM_COMMAND(
    OUTPUT    sozi.py
-   COMMAND   sed -e 's/{{SOZI_VERSION}}/${sozi_version}/g' ${CMAKE_CURRENT_SOURCE_DIR}/sozi.py > sozi.py
+   COMMAND   sed -e 's/{{SOZI_VERSION}}/${SOZI_VERSION}/g' ${CMAKE_CURRENT_SOURCE_DIR}/sozi.py > sozi.py
 )
 
 ADD_CUSTOM_COMMAND(
    OUTPUT    sozi_extras_addvideo.py
-   COMMAND   sed -e 's/{{SOZI_VERSION}}/${sozi_version}/g' ${CMAKE_CURRENT_SOURCE_DIR}/extras/sozi_extras_addvideo.py > sozi_extras_addvideo.py
+   COMMAND   sed -e 's/{{SOZI_VERSION}}/${SOZI_VERSION}/g' ${CMAKE_CURRENT_SOURCE_DIR}/extras/sozi_extras_addvideo.py > sozi_extras_addvideo.py
 )
 
 SET(sozi_inkscape_files ${CMAKE_CURRENT_SOURCE_DIR}/sozi.inx
@@ -32,7 +18,7 @@ SET(sozi_inkscape_files ${CMAKE_CURRENT_SOURCE_DIR}/sozi.inx
                         ${CMAKE_CURRENT_BINARY_DIR}/sozi_extras_addvideo.py)
 
 ################################################################################
-### The player core target
+### The inkscape integration files target
 ################################################################################
 
 #MESSAGE(WARNING "sozi_inkscape_files=${sozi_inkscape_files} sozi_player_files=${sozi_player_files}")
@@ -40,5 +26,8 @@ SET(sozi_inkscape_files ${CMAKE_CURRENT_SOURCE_DIR}/sozi.inx
 ADD_CUSTOM_TARGET(sozi_inkscape ALL DEPENDS ${sozi_inkscape_files} ${sozi_player_files})
 
 INSTALL(FILES ${sozi_inkscape_files}
-              ${sozi_player_files} 
-              DESTINATION ${inkscape_path}/extensions)
+              ${sozi_player_files}
+              ${sozi_doc_files}
+	      DESTINATION share/inkscape/extensions
+              COMPONENT inkscape_integration)
+

--- a/player/CMakeLists.txt
+++ b/player/CMakeLists.txt
@@ -41,7 +41,7 @@ SET(sozi_player_files "" PARENT_SCOPE)
 
 ADD_CUSTOM_COMMAND(
   OUTPUT    sozi.version
-  COMMAND   ${CMAKE_CURRENT_SOURCE_DIR}/tools/version sozi.version
+  COMMAND   echo ${SOZI_VERSION} > sozi.version
 )
 
 LIST(APPEND sozi_player_files ${CMAKE_CURRENT_BINARY_DIR}/sozi.version)
@@ -101,7 +101,8 @@ LIST(APPEND sozi_player_files ${CMAKE_CURRENT_BINARY_DIR}/sozi_extras_addvideo.j
 ADD_CUSTOM_TARGET(sozi_player ALL DEPENDS ${sozi_player_files})
 
 INSTALL(FILES ${sozi_player_files}
-              DESTINATION share/sozi)
+        DESTINATION share/sozi
+        COMPONENT player)
 
 ### Ugly hack because cmake don't keep PARENT_SCOPE with LIST(APPEND...
 SET(sozi_player_files ${sozi_player_files} PARENT_SCOPE)
@@ -137,7 +138,8 @@ LIST(APPEND sozi_header_files ${CMAKE_CURRENT_BINARY_DIR}/sozi.h)
 ADD_CUSTOM_TARGET(sozi_header ALL DEPENDS ${sozi_header_files})
 
 INSTALL(FILES ${sozi_header_files}
-              DESTINATION include)
+        DESTINATION include
+        COMPONENT player)
 
 ### Ugly hack because cmake don't keep PARENT_SCOPE with LIST(APPEND...
 SET(sozi_header_files ${sozi_header_files} PARENT_SCOPE)

--- a/player/tools/version
+++ b/player/tools/version
@@ -1,4 +1,0 @@
-#!/bin/sh
-
-date +%y.%m-%d%H%M%S > $1
-


### PR DESCRIPTION
Here is a first attempt to support packaging.

Here is an example of how to use the cmake build process and see what happen :
cd Sozi
mkdir build
cd build
cmake ../
make 
make install DESTDIR=install
make package

The changes :
- remove the version script and compute the version at the cmake level, so we have a SOZI_VERSION variable
- add the installation of the doc
- add the component differentiation.
- add cpack directives for building tar.gz archives

It still lacks the path of the archive to be the same as it used to be.

But, we can expect a gui interface for installation (http://www.vtk.org/Wiki/CMake:Component_Install_With_CPack).
