### PR TITLE
Add parallax support (for issue #225)

### DIFF
--- a/editors/inkscape/sozi/document.py
+++ b/editors/inkscape/sozi/document.py
@@ -76,6 +76,7 @@ class SoziFrame:
         self.sequence = read_xml_attr(self.xml, "sequence", "sozi", default_seq, int)
         self.hide = read_xml_attr(self.xml, "hide", "sozi", True, to_boolean)
         self.clip = read_xml_attr(self.xml, "clip", "sozi", True, to_boolean)
+        self.maximum_fitting = read_xml_attr(self.xml, "fitting", "sozi", "min") == "max"
         self.show_in_frame_list = read_xml_attr(self.xml, "show-in-frame-list", "sozi", True, to_boolean)
         self.timeout_enable = read_xml_attr(self.xml, "timeout-enable", "sozi", False, to_boolean)
         self.timeout_ms = read_xml_attr(self.xml, "timeout-ms", "sozi", 5000, float)
@@ -84,6 +85,7 @@ class SoziFrame:
         self.transition_profile = read_xml_attr(self.xml, "transition-profile", "sozi", "linear")
         self.transition_path = read_xml_attr(self.xml, "transition-path", "sozi")
         self.transition_path_hide = read_xml_attr(self.xml, "transition-path-hide", "sozi", True, to_boolean)
+        self.parallax = read_xml_attr(self.xml, "parallax", "sozi", 0, float)
         
         # Generate a frame id that does not look like a frame number
         id_suffix = (int(time.time()) + default_seq) % 10000
@@ -105,6 +107,7 @@ class SoziFrame:
         result.title = self.title
         result.hide = self.hide
         result.clip = self.clip
+        result.maximum_fitting = self.maximum_fitting
         result.show_in_frame_list = self.show_in_frame_list
         result.timeout_enable = self.timeout_enable
         result.timeout_ms = self.timeout_ms
@@ -113,6 +116,7 @@ class SoziFrame:
         result.transition_profile = self.transition_profile
         result.transition_path = self.transition_path
         result.transition_path_hide = self.transition_path_hide
+        result.parallax = self.parallax
 
         # Fill layers dict with copies of each layer object
         for l in self.layers.itervalues():
@@ -158,6 +162,7 @@ class SoziFrame:
             write_xml_attr(self.xml, "sequence", "sozi", self.sequence)
             write_xml_attr(self.xml, "hide", "sozi", "true" if self.hide else "false")
             write_xml_attr(self.xml, "clip", "sozi", "true" if self.clip else "false")
+            write_xml_attr(self.xml, "fitting", "sozi", "max" if self.maximum_fitting else "min")
             write_xml_attr(self.xml, "show-in-frame-list", "sozi", "true" if self.show_in_frame_list else "false")
             write_xml_attr(self.xml, "timeout-enable", "sozi", "true" if self.timeout_enable else "false")
             write_xml_attr(self.xml, "timeout-ms", "sozi", self.timeout_ms)
@@ -167,6 +172,7 @@ class SoziFrame:
             write_xml_attr(self.xml, "transition-path", "sozi", self.transition_path) # Optional
             write_xml_attr(self.xml, "transition-path-hide", "sozi", "true" if self.transition_path_hide else "false")
             write_xml_attr(self.xml, "id", None, self.id)
+            write_xml_attr(self.xml, "parallax", "sozi", self.parallax)
 
             for l in self.all_layers:
                 l.write()
@@ -197,10 +203,12 @@ class SoziLayer:
         # Missing attributes are inherited from the enclosing frame element
         self.hide = read_xml_attr(self.xml, "hide", "sozi", frame.hide, to_boolean)
         self.clip = read_xml_attr(self.xml, "clip", "sozi", frame.clip, to_boolean)
+        self.maximum_fitting = read_xml_attr(self.xml, "fitting", "sozi", "min") == "max"
         self.transition_zoom_percent = read_xml_attr(self.xml, "transition-zoom-percent", "sozi", frame.transition_zoom_percent, float)
         self.transition_profile = read_xml_attr(self.xml, "transition-profile", "sozi", frame.transition_profile)
         self.transition_path = read_xml_attr(self.xml, "transition-path", "sozi", frame.transition_path)
         self.transition_path_hide = read_xml_attr(self.xml, "transition-path-hide", "sozi", frame.transition_path_hide, to_boolean)
+        self.parallax = read_xml_attr(self.xml, "parallax", "sozi", frame.parallax, float)
 
         group_xml = frame.document.xml.xpath("//*[@id='" + self.group_id + "']")
         label_attr = inkex.addNS("label", "inkscape")
@@ -217,11 +225,13 @@ class SoziLayer:
         result.refid = self.refid
         result.hide = self.hide
         result.clip = self.clip
+        result.maximum_fitting = self.maximum_fitting
         result.transition_zoom_percent = self.transition_zoom_percent
         result.transition_profile = self.transition_profile
         result.transition_path = self.transition_path
         result.transition_path_hide = self.transition_path_hide
         result.label = self.label
+        result.parallax = self.parallax
 
         return result
 
@@ -244,10 +254,12 @@ class SoziLayer:
             write_xml_attr(self.xml, "refid", "sozi", self.refid)
             write_xml_attr(self.xml, "hide", "sozi", "true" if self.hide else "false")
             write_xml_attr(self.xml, "clip", "sozi", "true" if self.clip else "false")
+            write_xml_attr(self.xml, "fitting", "sozi", "max" if self.maximum_fitting else "min")
             write_xml_attr(self.xml, "transition-zoom-percent", "sozi", self.transition_zoom_percent)
             write_xml_attr(self.xml, "transition-profile", "sozi", self.transition_profile)
             write_xml_attr(self.xml, "transition-path", "sozi", self.transition_path)
             write_xml_attr(self.xml, "transition-path-hide", "sozi", "true" if self.transition_path_hide else "false")
+            write_xml_attr(self.xml, "parallax", "sozi", self.parallax)
             
         elif not self.is_new:
             # Remove element from the SVG document

--- a/editors/inkscape/sozi/ui.glade
+++ b/editors/inkscape/sozi/ui.glade
@@ -290,7 +290,7 @@
                                           <object class="GtkTable" id="table1">
                                             <property name="visible">True</property>
                                             <property name="can_focus">False</property>
-                                            <property name="n_rows">5</property>
+                                            <property name="n_rows">6</property>
                                             <property name="n_columns">2</property>
                                             <property name="column_spacing">12</property>
                                             <property name="row_spacing">3</property>
@@ -401,6 +401,21 @@
                                                     <property name="expand">True</property>
                                                     <property name="fill">True</property>
                                                     <property name="position">2</property>
+                                                  </packing>
+                                                </child>
+                                                <child>
+                                                  <object class="GtkCheckButton" id="maximum-fitting-field">
+                                                    <property name="label" translatable="yes">Maximum Fitting</property>
+                                                    <property name="use_action_appearance">False</property>
+                                                    <property name="visible">True</property>
+                                                    <property name="can_focus">True</property>
+                                                    <property name="receives_default">False</property>
+                                                    <property name="draw_indicator">True</property>
+                                                  </object>
+                                                  <packing>
+                                                    <property name="expand">True</property>
+                                                    <property name="fill">True</property>
+                                                    <property name="position">3</property>
                                                   </packing>
                                                 </child>
                                               </object>
@@ -521,6 +536,41 @@
                                                 <property name="top_attach">1</property>
                                                 <property name="bottom_attach">2</property>
                                                 <property name="x_options">GTK_FILL</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkLabel" id="parallax-label">
+                                                <property name="visible">True</property>
+                                                <property name="can_focus">False</property>
+                                                <property name="xalign">1</property>
+                                                <property name="label" translatable="yes">Parallax</property>
+                                                <property name="justify">right</property>
+                                              </object>
+                                              <packing>
+                                                <property name="top_attach">5</property>
+                                                <property name="bottom_attach">6</property>
+                                                <property name="x_options">GTK_FILL</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkSpinButton" id="parallax-field">
+                                                <property name="visible">True</property>
+                                                <property name="sensitive">False</property>
+                                                <property name="can_focus">True</property>
+                                                <property name="invisible_char">●</property>
+                                                <property name="primary_icon_activatable">False</property>
+                                                <property name="secondary_icon_activatable">False</property>
+                                                <property name="primary_icon_sensitive">True</property>
+                                                <property name="secondary_icon_sensitive">True</property>
+                                                <property name="adjustment">parallax-adjustment</property>
+                                                <property name="digits">0</property>
+                                                <property name="numeric">True</property>
+                                              </object>
+                                              <packing>
+                                                <property name="left_attach">1</property>
+                                                <property name="right_attach">2</property>
+                                                <property name="top_attach">5</property>
+                                                <property name="bottom_attach">6</property>
                                               </packing>
                                             </child>
                                           </object>
@@ -901,5 +951,11 @@
     <property name="upper">100</property>
     <property name="step_increment">5</property>
     <property name="page_increment">20</property>
+  </object>
+  <object class="GtkAdjustment" id="parallax-adjustment">
+    <property name="lower">0</property>
+    <property name="upper">1000</property>
+    <property name="step_increment">1</property>
+    <property name="page_increment">10</property>
   </object>
 </interface>

--- a/editors/inkscape/sozi/ui.py
+++ b/editors/inkscape/sozi/ui.py
@@ -113,6 +113,8 @@ class SoziUserInterface:
             "refid": SoziTextField(self, "refid", None, optional=True),
             "hide": SoziToggleField(self, "hide", True),
             "clip": SoziToggleField(self, "clip", True),
+            "maximum-fitting": SoziToggleField(self, "maximum-fitting", True),
+            "parallax": SoziSpinButtonField(self, "parallax", 0),
             "transition-zoom-percent": SoziSpinButtonField(self, "transition-zoom-percent", 0),
             "transition-profile": SoziComboField(self, "transition-profile", profiles, "linear"),
             "transition-path": SoziTextField(self, "transition-path", None, optional=True),

--- a/player/js/player.js
+++ b/player/js/player.js
@@ -171,15 +171,15 @@ namespace(this, "sozi.player", function (exports, window) {
             };
             
             data[idLayer].profile = profile || finalState[idLayer].transitionProfile;
-            data[idLayer].initialState.setAtState(initialState[idLayer]);
+            data[idLayer].initialState.setAtState(initialState[idLayer], true);
 
             // If the current layer is referenced in final state, copy the final properties
             // else, copy initial state to final state for the current layer.
             if (finalState.hasOwnProperty(idLayer)) {
-                data[idLayer].finalState.setAtState(finalState[idLayer]);
+                data[idLayer].finalState.setAtState(finalState[idLayer], true);
             }
             else {
-                data[idLayer].finalState.setAtState(initialState[idLayer]);
+                data[idLayer].finalState.setAtState(initialState[idLayer], true);
             }
 
             // Keep the smallest angle difference between initial state and final state
@@ -445,7 +445,7 @@ namespace(this, "sozi.player", function (exports, window) {
          */
         onDone: function () {
             for (var idLayer in this.data) {
-                viewPort.cameras[idLayer].setAtState(this.data[idLayer].finalState);
+                viewPort.cameras[idLayer].setAtState(this.data[idLayer].finalState, true);
             }
 
             viewPort.update();


### PR DESCRIPTION
0 means parallax disabled

Otherwise, the value corresponds to a scaling value. 1 is doesn't really
scale the layer. Values greater than 1 will zoom in to the layer and values
between 0 and 1 will scale down the layer.

Some adjustments may still be necessary.

The pull request has been done on the master branch because the dev branch was too foreign (with the javascript editor). The changes should be able to be ported to the dev branch.
