### PR TITLE
SVG didn't render properly in Internet Explorer 11

### DIFF
--- a/templates/player.html
+++ b/templates/player.html
@@ -7,6 +7,7 @@
 <html>
     <head>
         <meta charset="utf-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <title>{{ pres.title }}</title>
         <style>
             body {


### PR DESCRIPTION
This patch fixes the Sozi player template to make SVG render properly
under Internet Explorer 11.  See http://stackoverflow.com/a/27494616