### PR TITLE
Unlink first selected frame before moving it (#332)

### DIFF
--- a/js/Controller.js
+++ b/js/Controller.js
@@ -150,8 +150,20 @@ Controller.moveFrames = function (toFrameIndex) {
         }
     });
 
+    // Save layer properties for first selected frame
+    var firstFrameLinkValues = [];
+    framesByIndex[0].layerProperties.forEach(layer => {
+        firstFrameLinkValues.push(layer.link);
+    });
+
+
     this.perform(
         function onDo() {
+            // Unlink first selected frame before moving it
+            framesByIndex[0].layerProperties.forEach(layer => {
+                layer.link = false;
+            });
+
             // Move the selected frames to the given index.
             framesByIndex.forEach(frame => {
                 this.presentation.frames.splice(frame.index, 1);
@@ -162,6 +174,10 @@ Controller.moveFrames = function (toFrameIndex) {
             this.presentation.updateLinkedLayers();
         },
         function onUndo() {
+            // Restore layer properties for the first selected frame
+            framesByIndex[0].layerProperties.forEach((layer, i) => {
+                layer.link = firstFrameLinkValues[i];
+            });
             // Move the selected frames to their original locations.
             framesByIndex.forEach(frame => {
                 this.presentation.frames.splice(frame.index, 1);


### PR DESCRIPTION
A simple implementation of the bug described in #332. I think there's more to think about here. For example, say you move frame 1 to be frame 4, and 5 is linked, then it will still be linked, but to the new 4. That might cause some head ache.

Or you want to move frame 4, 9 and 10, and frame 9 is linked. That will also cause a problem. This is probably not going to happen too often, but might be worth a consideration.

Anyway, this PR deals with the most obvious use case, moving one or more frames, and unlinking the first one. Since I'm not able to make new pull requests on the dev branch, I created a new branch, hope that's fine.