### PR TITLE
Some more keyboard shortcuts

### DIFF
--- a/js/Controller.js
+++ b/js/Controller.js
@@ -208,6 +208,29 @@ Controller.removeLayerFromSelection = function (layer) {
 };
 
 /*
+ * Select a specific frame.
+ *
+ * Parameters:
+ *  - relativeIndex: select frame relative to current selection.
+ *  - index: select this particular index
+ *           A negative number counts backwards from the end
+ */
+Controller.selectFrame = function (relativeIndex, index) {
+    var layers = this.selection.selectedLayers; 
+    if (relativeIndex != 0) {
+        var target = this.selection.currentFrame.index + relativeIndex;
+        var lastIndex = this.presentation.frames.length - 1;
+        target = target < 0 ? 0 : (target > lastIndex ? lastIndex : target);
+        this.updateLayerAndFrameSelection(false, false, layers, target);
+    }
+    else {
+        if (index < 0)
+            index = this.presentation.frames.length + index;
+        this.updateLayerAndFrameSelection(false, false, layers, index);
+    }
+}
+
+/*
  * Update the selection for a given frame.
  *
  * Parameters:

--- a/js/editor.js
+++ b/js/editor.js
@@ -84,8 +84,37 @@ window.addEventListener("load", () => {
                     return;
             }
         }
-        else {
+        else if (/INPUT|SELECT|TEXTAREA/.test(document.activeElement.tagName)) {
+            // Don't catch keys when in focus is in input elements
             return;
+        }
+        else {
+            var pres = Controller.presentation;
+            var selection = Controller.selection;
+            var layers = selection.selectedLayers; 
+            switch (evt.keyCode) {
+                case 35: // End
+                    var lastFrame = pres.frames.length -1;
+                    Controller.updateLayerAndFrameSelection(false, false, layers, lastFrame);
+                    break;
+                case 36: // Home
+                    Controller.updateLayerAndFrameSelection(false, false, layers, 0);
+                    break;
+                case 37: // Left
+                case 38: // Up
+                    var target = selection.currentFrame.index -1;
+                    target = target < 0 ? 0 : target;
+                    Controller.updateLayerAndFrameSelection(false, false, layers, target);
+                    break;
+                case 39: // Right
+                case 40: // Down
+                    var target = selection.currentFrame.index +1;
+                    target = target > pres.frames.length -1 ? pres.frames.length -1 : target;
+                    Controller.updateLayerAndFrameSelection(false, false, layers, target);
+                    break;
+                default:
+                    return;
+            }
         }
         // Chrome already supports undo/redo in input elements
         evt.preventDefault();

--- a/js/editor.js
+++ b/js/editor.js
@@ -89,28 +89,20 @@ window.addEventListener("load", () => {
         }
         else {
             if (!/INPUT|SELECT|TEXTAREA/.test(document.activeElement.tagName)) {
-                var pres = Controller.presentation;
-                var selection = Controller.selection;
-                var layers = selection.selectedLayers; 
                 switch (evt.keyCode) {
                     case 35: // End
-                        var lastFrame = pres.frames.length -1;
-                        Controller.updateLayerAndFrameSelection(false, false, layers, lastFrame);
+                        Controller.selectFrame(0, -1);
                         break;
                     case 36: // Home
-                        Controller.updateLayerAndFrameSelection(false, false, layers, 0);
+                        Controller.selectFrame(0, 0);
                         break;
                     case 37: // Left
                     case 38: // Up
-                        var target = selection.currentFrame.index -1;
-                        target = target < 0 ? 0 : target;
-                        Controller.updateLayerAndFrameSelection(false, false, layers, target);
+                        Controller.selectFrame(-1, 0);
                         break;
                     case 39: // Right
                     case 40: // Down
-                        var target = selection.currentFrame.index +1;
-                        target = target > pres.frames.length -1 ? pres.frames.length -1 : target;
-                        Controller.updateLayerAndFrameSelection(false, false, layers, target);
+                        Controller.selectFrame(1, 0);
                         break;
                     case 46: // Delete
                         Controller.deleteFrames();

--- a/js/editor.js
+++ b/js/editor.js
@@ -84,38 +84,46 @@ window.addEventListener("load", () => {
                     return;
             }
         }
-        else if (/INPUT|SELECT|TEXTAREA/.test(document.activeElement.tagName)) {
-            // Don't catch keys when in focus is in input elements
-            return;
-        }
         else {
-            var pres = Controller.presentation;
-            var selection = Controller.selection;
-            var layers = selection.selectedLayers; 
+            if (!/INPUT|SELECT|TEXTAREA/.test(document.activeElement.tagName)) {
+                var pres = Controller.presentation;
+                var selection = Controller.selection;
+                var layers = selection.selectedLayers; 
+                switch (evt.keyCode) {
+                    case 35: // End
+                        var lastFrame = pres.frames.length -1;
+                        Controller.updateLayerAndFrameSelection(false, false, layers, lastFrame);
+                        break;
+                    case 36: // Home
+                        Controller.updateLayerAndFrameSelection(false, false, layers, 0);
+                        break;
+                    case 37: // Left
+                    case 38: // Up
+                        var target = selection.currentFrame.index -1;
+                        target = target < 0 ? 0 : target;
+                        Controller.updateLayerAndFrameSelection(false, false, layers, target);
+                        break;
+                    case 39: // Right
+                    case 40: // Down
+                        var target = selection.currentFrame.index +1;
+                        target = target > pres.frames.length -1 ? pres.frames.length -1 : target;
+                        Controller.updateLayerAndFrameSelection(false, false, layers, target);
+                        break;
+                }
+            }
             switch (evt.keyCode) {
-                case 35: // End
-                    var lastFrame = pres.frames.length -1;
-                    Controller.updateLayerAndFrameSelection(false, false, layers, lastFrame);
+                case 113: // F2
+                    document.getElementById('field-title').select();
                     break;
-                case 36: // Home
-                    Controller.updateLayerAndFrameSelection(false, false, layers, 0);
+                case 116: // F5
+                    Controller.reload();
                     break;
-                case 37: // Left
-                case 38: // Up
-                    var target = selection.currentFrame.index -1;
-                    target = target < 0 ? 0 : target;
-                    Controller.updateLayerAndFrameSelection(false, false, layers, target);
+                case 122: // F11
+                    document.getElementById('btn-fullscreen').click();
                     break;
-                case 39: // Right
-                case 40: // Down
-                    var target = selection.currentFrame.index +1;
-                    target = target > pres.frames.length -1 ? pres.frames.length -1 : target;
-                    Controller.updateLayerAndFrameSelection(false, false, layers, target);
-                    break;
-                default:
-                    return;
             }
         }
+        return;
         // Chrome already supports undo/redo in input elements
         evt.preventDefault();
     }, false);

--- a/js/editor.js
+++ b/js/editor.js
@@ -74,6 +74,9 @@ window.addEventListener("load", () => {
     window.addEventListener("keydown", (evt) => {
         if (evt.ctrlKey) {
             switch (evt.keyCode) {
+                case 83: // Ctrl-s
+                    Controller.save();
+                    break;
                 case 89: // Ctrl-y
                     Controller.redo();
                     break;
@@ -108,6 +111,9 @@ window.addEventListener("load", () => {
                         var target = selection.currentFrame.index +1;
                         target = target > pres.frames.length -1 ? pres.frames.length -1 : target;
                         Controller.updateLayerAndFrameSelection(false, false, layers, target);
+                        break;
+                    case 46: // Delete
+                        Controller.deleteFrames();
                         break;
                 }
             }

--- a/js/view/Toolbar.js
+++ b/js/view/Toolbar.js
@@ -95,7 +95,8 @@ Toolbar.render = function () {
         ]),
         h("span.group",
             h("button", {
-                title: screenfull.isFullscreen ? _("Disable full-screen mode") : _("Enable full-screen mode"),
+                title: screenfull.isFullscreen ? _("Disable full-screen mode (F11)") : _("Enable full-screen mode (F11)"),
+                id: "btn-fullscreen",
                 className: screenfull.isFullscreen ? "active" : undefined,
                 disabled: !screenfull.enabled,
                 onclick() { screenfull.toggle(document.documentElement); }
@@ -108,7 +109,7 @@ Toolbar.render = function () {
                 onclick() { c.save(); }
             }, h("i.fa.fa-download")), // "download" icon preferred to the official "save" icon
             h("button", {
-                title: _("Reload the SVG document"),
+                title: _("Reload the SVG document (F5)"),
                 onclick() { c.reload(); }
             }, h("i.fa.fa-refresh"))
         ]),


### PR DESCRIPTION
I've added some more keyboard shortcuts that I think are pretty self-explanatory:

```
Ctrl+s        Save
Del           Delete selected frames
Left, Up      Move to previous frame
Right, Down   Move to next frame
Home          Move to first frame
End           Move to last frame
F2            Change frame title
F5            Reload SVG document
F11           Toggle fullscreen
```

I couldn't manage to catch ctrl+a (for selecting all frames), since it seems blocked/used by node-webkit. I'd also like to have some shortcuts for the four different tools (move, rotate, zoom and clip), but I'm not sure which keys to assign.