### PR TITLE
Optionally preview transitions in editor

### DIFF
--- a/js/Controller.js
+++ b/js/Controller.js
@@ -193,7 +193,7 @@ Controller.moveFrames = function (toFrameIndex) {
             this.presentation.updateLinkedLayers();
         },
         false,
-        ["presentationChange", "editorStateChange", "repaint"]
+        ["presentationChange", "editorStateChange", "frameChange", "repaint"]
     );
 };
 
@@ -207,6 +207,7 @@ Controller.selectLayers = function (layers) {
     this.selection.selectedLayers = layers.slice();
     this.updateCameraSelection();
     this.emit("editorStateChange");
+    this.emit("frameChange");
     this.emit("repaint");
 };
 
@@ -291,6 +292,7 @@ Controller.updateFrameSelection = function (single, sequence, frameIndex) {
 
     // Trigger a repaint of the editor views.
     this.emit("editorStateChange");
+    this.emit("frameChange");
     this.emit("repaint");
 };
 
@@ -373,6 +375,7 @@ Controller.updateLayerAndFrameSelection = function (single, sequence, layers, fr
 
     // Trigger a repaint of the editor views.
     this.emit("editorStateChange");
+    this.emit("frameChange");
     this.emit("repaint");
 };
 
@@ -741,3 +744,4 @@ Controller.redo = function () {
     action.onDo.call(this);
     action.events.forEach(evt => { this.emit(evt); });
 };
+

--- a/js/editor.js
+++ b/js/editor.js
@@ -31,7 +31,7 @@ window.addEventListener("load", () => {
 
     var locale = i18n.init();
     Properties.init(document.getElementById("sozi-editor-view-properties"), Selection, Controller, locale);
-    Toolbar.init(document.getElementById("sozi-editor-view-toolbar"), Storage, Presentation, Viewport, Controller, locale);
+    Toolbar.init(document.getElementById("sozi-editor-view-toolbar"), Storage, Presentation, Viewport, Controller, locale, Player);
     Timeline.init(document.getElementById("sozi-editor-view-timeline"), Presentation, Selection, Controller, locale);
     Storage.init(Controller, SVGDocument, Presentation, Selection, Timeline, locale);
 
@@ -108,6 +108,9 @@ window.addEventListener("load", () => {
                         break;
                     case 46: // Delete
                         Controller.deleteFrames();
+                        break;
+                    case 80: // P
+                        document.getElementById('btn-preview-transitions').click();
                         break;
                 }
             }

--- a/js/editor.js
+++ b/js/editor.js
@@ -9,6 +9,7 @@ import {Presentation} from "./model/Presentation";
 import {Selection} from "./model/Selection";
 import {Storage} from "./Storage";
 import {Viewport} from "./player/Viewport";
+import {Player} from "./player/Player";
 import {Controller} from "./Controller";
 import {Preview} from "./view/Preview";
 import {Properties} from "./view/Properties";
@@ -22,10 +23,11 @@ window.addEventListener("load", () => {
 
     Selection.init(Presentation);
     Viewport.init(Presentation, true);
+    Player.init(Viewport, Presentation, true);
 
     Controller.init(Storage, Presentation, Selection, Viewport);
 
-    Preview.init(document.getElementById("sozi-editor-view-preview"), Presentation, Selection, Viewport, Controller);
+    Preview.init(document.getElementById("sozi-editor-view-preview"), Presentation, Selection, Viewport, Controller, Player);
 
     var locale = i18n.init();
     Properties.init(document.getElementById("sozi-editor-view-properties"), Selection, Controller, locale);

--- a/js/player/Player.js
+++ b/js/player/Player.js
@@ -35,6 +35,7 @@ Player.init = function (viewport, presentation, editMode) {
     this.targetFrameIndex = 0;
     this.timeoutHandle = null;
     this.transitions = [];
+    this.previewTransitions = false;
 
     this.setupEventHandlers();
     return this;
@@ -228,6 +229,7 @@ Player.pause = function () {
         this.waitingTimeout = false;
     }
     this.playing = false;
+    this.previewTransitions = false;
     this.targetFrameIndex = this.currentFrameIndex;
     return this;
 };
@@ -236,6 +238,7 @@ Player.pause = function () {
  * Resume playing from the current frame.
  */
 Player.resume = function () {
+    this.previewTransitions = true;
     this.playFromIndex(this.currentFrameIndex);
     return this;
 };

--- a/js/player/Player.js
+++ b/js/player/Player.js
@@ -23,10 +23,11 @@ var ROTATE_STEP = 5;
 
 export var Player = Object.create(EventEmitter.prototype);
 
-Player.init = function (viewport, presentation) {
+Player.init = function (viewport, presentation, editMode) {
     EventEmitter.call(this);
     this.viewport = viewport;
     this.presentation = presentation;
+    this.editMode = !!editMode;
     this.animator = Object.create(Animator).init();
     this.playing = false;
     this.waitingTimeout = false;
@@ -40,11 +41,13 @@ Player.init = function (viewport, presentation) {
 };
 
 Player.setupEventHandlers = function () {
-    this.viewport.addListener("click", this.onClick.bind(this));
-    this.viewport.addListener("dragStart", this.pause.bind(this));
-    this.viewport.addListener("userChangeState", this.pause.bind(this));
-    window.addEventListener("keydown", this.onKeyDown.bind(this), false);
-    window.addEventListener("keypress", this.onKeyPress.bind(this), false);
+    if (!this.editMode) {
+        this.viewport.addListener("click", this.onClick.bind(this));
+        this.viewport.addListener("dragStart", this.pause.bind(this));
+        this.viewport.addListener("userChangeState", this.pause.bind(this));
+        window.addEventListener("keydown", this.onKeyDown.bind(this), false);
+        window.addEventListener("keypress", this.onKeyPress.bind(this), false);
+    }
     this.animator.addListener("step", this.onAnimatorStep.bind(this));
     this.animator.addListener("stop", this.onAnimatorStop.bind(this));
     this.animator.addListener("done", this.onAnimatorDone.bind(this));

--- a/js/view/Preview.js
+++ b/js/view/Preview.js
@@ -8,12 +8,13 @@ var PREVIEW_MARGIN = 15;
 
 export var Preview = {
 
-    init(container, presentation, selection, viewport, controller) {
+    init(container, presentation, selection, viewport, controller, player) {
         this.container = container;
         this.presentation = presentation;
         this.selection = selection;
         this.viewport = viewport;
         this.controller = controller;
+        this.player = player;
 
         controller.addListener("loadSVG", this.onLoadSVG.bind(this));
         $(window).resize(this.repaint.bind(this));
@@ -25,8 +26,10 @@ export var Preview = {
         this.viewport.addListener("click", this.onClick.bind(this));
         this.viewport.addListener("userChangeState", this.controller.updateCameraStates.bind(this.controller));
         this.controller.addListener("repaint", this.repaint.bind(this));
+        this.controller.addListener("frameChange", this.onFrameChange.bind(this));
         this.container.addEventListener("mouseenter", this.onMouseEnter.bind(this), false);
         this.container.addEventListener("mouseleave", this.onMouseLeave.bind(this), false);
+        this.player.addListener("frameChange", this.onAnimatorDone.bind(this));
 
         $("html head title").text(this.presentation.title);
         $(this.container).html(this.presentation.document.root);
@@ -96,4 +99,17 @@ export var Preview = {
         this.viewport.showHiddenElements = false;
         this.viewport.repaint();
     }
+
+    onFrameChange() {
+        // TODO: optional transition!
+        this.player.moveToFrame(this.selection.currentFrame.index);
+    },
+
+    onAnimatorDone() {
+        if (this.selection.currentFrame.index !== this.player.currentFrameIndex) {
+            this.controller.selectFrame(this.player.currentFrameIndex);
+        }
+        this.controller.emit("editorStateChange");
+        this.controller.emit("repaint");
+    },
 };

--- a/js/view/Preview.js
+++ b/js/view/Preview.js
@@ -98,11 +98,15 @@ export var Preview = {
         });
         this.viewport.showHiddenElements = false;
         this.viewport.repaint();
-    }
+    },
 
     onFrameChange() {
-        // TODO: optional transition!
-        this.player.moveToFrame(this.selection.currentFrame.index);
+        if (this.player.previewTransitions) {
+            this.player.moveToFrame(this.selection.currentFrame.index);
+        }
+        else {
+            this.player.jumpToFrame(this.selection.currentFrame.index);
+        }
     },
 
     onAnimatorDone() {
@@ -111,5 +115,5 @@ export var Preview = {
         }
         this.controller.emit("editorStateChange");
         this.controller.emit("repaint");
-    },
+    }
 };

--- a/js/view/Toolbar.js
+++ b/js/view/Toolbar.js
@@ -11,13 +11,14 @@ import pkg from "../../package.json";
 
 export var Toolbar = Object.create(VirtualDOMView);
 
-Toolbar.init = function (container, storage, presentation, viewport, controller, locale) {
+Toolbar.init = function (container, storage, presentation, viewport, controller, locale, player) {
     VirtualDOMView.init.call(this, container, controller);
 
     this.storage = storage;
     this.presentation = presentation;
     this.viewport = viewport;
     this.gettext = locale.gettext.bind(locale);
+    this.player = player;
 
     return this;
 };
@@ -26,6 +27,7 @@ Toolbar.render = function () {
     var _ = this.gettext;
     var c = this.controller;
     var v = this.viewport;
+    var p = this.player;
     return h("div", [
         h("span.group", [
             _("Aspect ratio: "),
@@ -93,15 +95,24 @@ Toolbar.render = function () {
                 onclick() { c.redo(); }
             }, h("i.fa.fa-share")) // "share" icon preferred to the official "redo" icon
         ]),
-        h("span.group",
+        h("span.group.btn-group", [
             h("button", {
                 title: screenfull.isFullscreen ? _("Disable full-screen mode (F11)") : _("Enable full-screen mode (F11)"),
                 id: "btn-fullscreen",
                 className: screenfull.isFullscreen ? "active" : undefined,
                 disabled: !screenfull.enabled,
                 onclick() { screenfull.toggle(document.documentElement); }
-            }, h("i.fa.fa-desktop"))
-        ),
+            }, h("i.fa.fa-desktop")),
+            h("button", {
+                title: _("Preview transitions (P)"),
+                id: "btn-preview-transitions",
+                className: p.previewTransitions ? "active" : undefined,
+                onclick() {
+                    p.previewTransitions ? p.pause() : p.resume();
+                    c.emit("repaint");
+                }
+            }, h("i.fa.fa-play-circle"))
+        ]),
         h("span.group.btn-group", [
             h("button", {
                 title: _("Save the presentation (Ctrl-S)"),


### PR DESCRIPTION
Yet another pull request ;)

This one is making it possible to preview the transitions right away in the editor. I've mentioned it in the feature request #326, but I've implemented it a little bit different. It's now only a toggle button to choose whether or not to preview the transitions. The transition is then previewed by changing selected frame. It's really convenient with the arrow keys now working as well. I've tried to tweak the Player itself as little as possible. I really like how the clip boxes also resizes in real time when hovering over the preview viewport when previewing the transitions. I assigned the key `P` to toggle preview of transitions. I think it's close enough to how `P` works in the presentation later on, feel free to disagree.
