### PR TITLE
Invert/revert relative zoom (Fix #334)

### DIFF
--- a/js/player/Camera.js
+++ b/js/player/Camera.js
@@ -279,7 +279,7 @@ Camera.interpolate = function (initialState, finalState, progress, timingFunctio
     }
 
     function quadratic(u0, u1) {
-        var um = (relativeZoom > 0 ? Math.max(u0, u1) : Math.min(u0, u1)) * (1 + relativeZoom);
+        var um = (relativeZoom > 0 ? Math.max(u0, u1) : Math.min(u0, u1)) * (1 - relativeZoom);
         var du0 = u0 - um;
         var du1 = u1 - um;
         var r = Math.sqrt(du0 / du1);


### PR DESCRIPTION
A simple bug fix. See #334 for more information. Not sure why relative zoom in is linear and zooming out is easing, but that's another issue.