### PR TITLE
fix HTML-escaped JS in player

### DIFF
--- a/templates/player.html
+++ b/templates/player.html
@@ -108,6 +108,6 @@
         <div class="sozi-blank-screen"></div>
         <script>var soziPresentationData = {{ json }};</script>
 {% endraw %}
-        <script>{{ playerJs }}</script>
+        <script>{{'{% raw %}'}}{{ playerJs|safe }}{{'{% endraw %}'}}</script>
     </body>
 </html>


### PR DESCRIPTION
nunjucks 3 (in fact 2.x+) HTML-escapes output by default. This results in a non-functional player file (as the JS inside is broken). This change marks the player JS as safe in the template and wraps it in a *raw* block in the output so its contents doesn't interfere when the template is applied for the second time.